### PR TITLE
feat(messaging): implement NIP-09 message deletion with privacy-first design

### DIFF
--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.12.2",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.12.2",
+      "version": "0.12.4",
       "dependencies": {
         "@noble/hashes": "^1.3.1",
         "@types/chokidar": "^1.7.5",

--- a/src/lib/components/ChatView.svelte
+++ b/src/lib/components/ChatView.svelte
@@ -1698,6 +1698,69 @@
     }
   }
 
+  // Delete confirmation state
+  let showDeleteConfirm = $state(false);
+  let messageToDelete = $state<Message | null>(null);
+  let isDeleting = $state(false);
+
+  function deleteMessage() {
+    if (!contextMenu.message) return;
+    messageToDelete = contextMenu.message;
+    showDeleteConfirm = true;
+  }
+
+  function cancelDelete() {
+    showDeleteConfirm = false;
+    messageToDelete = null;
+  }
+
+  async function confirmDelete() {
+    if (!messageToDelete || isDeleting) return;
+
+    isDeleting = true;
+    hapticLightImpact();
+    
+    // Close dialog immediately for better UX
+    const messageToDeleteCopy = messageToDelete;
+    showDeleteConfirm = false;
+    messageToDelete = null;
+    isDeleting = false;
+
+    // Send deletion in background
+    try {
+      await messagingService.sendDeletionRequest(messageToDeleteCopy);
+    } catch (e) {
+      console.error('Failed to delete message:', e);
+      
+      // Rollback: unmark the message as deleted so user can retry
+      if (messageToDeleteCopy.id) {
+        try {
+          await messageRepo.unmarkMessageDeleted(messageToDeleteCopy.id);
+          
+          // Emit event to refresh UI and show message again
+          if (typeof window !== 'undefined') {
+            window.dispatchEvent(new CustomEvent('nospeak:message-deleted', {
+              detail: { 
+                messageId: messageToDeleteCopy.id,
+                conversationId: messageToDeleteCopy.conversationId || messageToDeleteCopy.recipientNpub,
+                rumorId: messageToDeleteCopy.rumorId
+              }
+            }));
+          }
+        } catch (rollbackError) {
+          console.error('Failed to rollback deletion:', rollbackError);
+        }
+      }
+      
+      await nativeDialogService.alert({
+        title: translate('chat.delete.failedTitle'),
+        message: translate('chat.delete.failedMessagePrefix') + (e as Error).message
+      });
+    }
+  }
+
+
+
   async function handleFileSelect(file: File, type: 'image' | 'video' | 'audio' | 'file') {
     // For 1-on-1 chats, need partnerNpub; for groups, need groupConversation
     if (!isGroup && !partnerNpub) return;
@@ -2221,6 +2284,7 @@
                 fileWidth={msg.fileWidth}
                 fileHeight={msg.fileHeight}
                 fileBlurhash={msg.fileBlurhash}
+                deletedAt={msg.deletedAt}
               />
               {#if msg.eventId?.startsWith('optimistic:') && msg.rumorKind === 15}
                 <UploadProgressOverlay eventId={msg.eventId} />
@@ -2427,6 +2491,60 @@
     </div>
   </div>
   {/if}
+
+  <!-- Delete Confirmation Dialog -->
+  {#if showDeleteConfirm && messageToDelete}
+    <div
+      class="fixed inset-0 z-[10000] flex items-center justify-center p-4"
+      onclick={(e) => { if (e.target === e.currentTarget) cancelDelete(); }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="delete-dialog-title"
+    >
+      <!-- Backdrop -->
+      <div class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
+      
+      <!-- Dialog -->
+      <div class="relative bg-white/90 dark:bg-slate-900/90 backdrop-blur-xl border border-gray-200 dark:border-slate-700 rounded-2xl shadow-2xl p-6 max-w-md w-full">
+        <h3 
+          id="delete-dialog-title"
+          class="text-lg font-bold text-gray-900 dark:text-white mb-4"
+        >
+          {$t('chat.delete.confirmTitle')}
+        </h3>
+        <div class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3 mb-6">
+          <p class="text-xs text-amber-800 dark:text-amber-300">
+            {$t('chat.delete.privacyNotice')}
+          </p>
+        </div>
+
+        <div class="flex gap-3 justify-end">
+          <button
+            type="button"
+            onclick={cancelDelete}
+            disabled={isDeleting}
+            class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-lg transition-colors disabled:opacity-50"
+          >
+            {$t('chat.delete.cancel')}
+          </button>
+          <button
+            type="button"
+            onclick={confirmDelete}
+            disabled={isDeleting}
+            class="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-700 rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+          >
+            {#if isDeleting}
+              <svg class="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+            {/if}
+            {$t('chat.delete.confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  {/if}
 </div>
 
 {#if isGroup && groupConversation}
@@ -2453,6 +2571,8 @@
   onReact={reactToMessage}
   onCopy={copyMessage}
   onFavorite={handleFavorite}
+  onDelete={deleteMessage}
   isFavorited={contextMenu.message?.eventId ? $favoriteEventIds.has(contextMenu.message.eventId) : false}
+  canDelete={contextMenu.message ? messagingService.canDeleteMessage(contextMenu.message) : false}
   message={contextMenu.message}
 />

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { t } from '$lib/i18n';
 
-    let { x = 0, y = 0, isOpen = false, onClose, onCite, onReact, onCopy, onFavorite, isFavorited = false, message } = $props<{
+    let { x = 0, y = 0, isOpen = false, onClose, onCite, onReact, onCopy, onFavorite, onDelete, isFavorited = false, canDelete = false, message } = $props<{
         x: number;
         y: number;
         isOpen: boolean;
@@ -10,7 +10,9 @@
         onReact?: (emoji: '👍' | '❤️' | '😂' | '🙏') => void;
         onCopy?: () => void;
         onFavorite?: () => void;
+        onDelete?: () => void;
         isFavorited?: boolean;
+        canDelete?: boolean;
         message?: { sentAt: number } | null;
     }>();
 
@@ -130,6 +132,14 @@
                 onclick={() => { onFavorite(); onClose(); }}
             >
                 {isFavorited ? $t('chat.contextMenu.unfavorite') : $t('chat.contextMenu.favorite')}
+            </button>
+        {/if}
+        {#if onDelete && canDelete}
+            <button 
+                class="w-full text-start px-4 py-2 hover:bg-red-100/70 dark:hover:bg-red-900/30 text-sm text-red-600 dark:text-red-400 transition-colors border-t border-gray-200/70 dark:border-slate-700/70"
+                onclick={() => { onDelete(); onClose(); }}
+            >
+                {$t('chat.contextMenu.delete')}
             </button>
         {/if}
     </div>

--- a/src/lib/components/MessageContent.svelte
+++ b/src/lib/components/MessageContent.svelte
@@ -37,7 +37,8 @@
         forceEagerLoad = false,
         fileWidth = undefined,
         fileHeight = undefined,
-        fileBlurhash = undefined
+        fileBlurhash = undefined,
+        deletedAt = undefined
     } = $props<{
         content: string;
         highlight?: string;
@@ -56,6 +57,7 @@
         fileWidth?: number;
         fileHeight?: number;
         fileBlurhash?: string;
+        deletedAt?: number;
     }>();
 
     const urlRegex = /(https?:\/\/[^\s]+)/g;
@@ -817,7 +819,16 @@
  <!-- svelte-ignore a11y_no_static_element_interactions -->
  <div bind:this={container} onclick={handleNpubInteraction} onkeydown={handleNpubInteraction} class={`whitespace-pre-wrap break-anywhere leading-relaxed ${isSingleEmoji ? 'text-4xl' : ''}`}>
 
-    {#if location}
+    {#if deletedAt}
+        <!-- Deleted message placeholder -->
+        <div class="flex items-center gap-2 text-gray-400 dark:text-gray-600 italic text-sm py-1">
+            <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="3 6 5 6 21 6"></polyline>
+                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+            </svg>
+            <span>{$t('chat.messageDeleted')}</span>
+        </div>
+    {:else if location}
         <div class="my-1">
             <div class="flex items-center gap-2 typ-meta text-xs font-semibold text-gray-600 dark:text-slate-300 leading-none">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/lib/core/Messaging.ts
+++ b/src/lib/core/Messaging.ts
@@ -182,9 +182,9 @@ import type { Conversation } from '$lib/db/db';
       }
       const rumor = rumorCandidate as NostrEvent;
 
-      // Support both legacy Kind 15 and current Kind 14 rumors, plus kind 7 reactions
-      if (rumor.kind !== 14 && rumor.kind !== 15 && rumor.kind !== 7) {
-        throw new Error(`Expected Rumor (Kind 14, 15, or 7), got ${rumor.kind}`);
+      // Support both legacy Kind 15 and current Kind 14 rumors, plus kind 7 reactions and kind 5 deletions
+      if (rumor.kind !== 14 && rumor.kind !== 15 && rumor.kind !== 7 && rumor.kind !== 5) {
+        throw new Error(`Expected Rumor (Kind 14, 15, 7, or 5), got ${rumor.kind}`);
       }
 
       // NIP-17: Verify seal pubkey matches rumor pubkey to prevent sender impersonation
@@ -205,6 +205,11 @@ import type { Conversation } from '$lib/db/db';
 
       if (rumor.kind === 7) {
         await this.processReactionRumor(rumor, event.id);
+        return;
+      }
+
+      if (rumor.kind === 5) {
+        await this.processDeletionRumor(rumor, event.id);
         return;
       }
 
@@ -256,9 +261,9 @@ import type { Conversation } from '$lib/db/db';
       }
       const rumor = rumorCandidate as NostrEvent;
 
-      // Support both legacy Kind 15 and current Kind 14 rumors, plus kind 7 reactions
-      if (rumor.kind !== 14 && rumor.kind !== 15 && rumor.kind !== 7) {
-        throw new Error(`Expected Rumor (Kind 14, 15, or 7), got ${rumor.kind}`);
+      // Support both legacy Kind 15 and current Kind 14 rumors, plus kind 7 reactions and kind 5 deletions
+      if (rumor.kind !== 14 && rumor.kind !== 15 && rumor.kind !== 7 && rumor.kind !== 5) {
+        throw new Error(`Expected Rumor (Kind 14, 15, 7, or 5), got ${rumor.kind}`);
       }
 
       // NIP-17: Verify seal pubkey matches rumor pubkey to prevent sender impersonation
@@ -279,6 +284,11 @@ import type { Conversation } from '$lib/db/db';
 
       if (rumor.kind === 7) {
         await this.processReactionRumor(rumor, event.id);
+        return null;
+      }
+
+      if (rumor.kind === 5) {
+        await this.processDeletionRumor(rumor, event.id);
         return null;
       }
 
@@ -640,6 +650,216 @@ import type { Conversation } from '$lib/db/db';
     }
   }
 
+
+  /**
+   * Process a deletion rumor (kind 5) wrapped in a gift wrap.
+   * Validates that the deletion comes from the original message sender
+   * and marks the message as deleted in the local database.
+   */
+  private async processDeletionRumor(rumor: NostrEvent, originalEventId: string): Promise<void> {
+    const s = get(signer);
+    if (!s) return;
+
+    try {
+      const myPubkey = await s.getPublicKey();
+
+      // Verify p-tags include my pubkey (already validated in handleGiftWrap, but double-check)
+      const pTags = rumor.tags.filter(t => Array.isArray(t) && t.length >= 2 && t[0] === 'p');
+      const myPubkeyInPTags = pTags.some(t => t[1] === myPubkey);
+
+      if (!myPubkeyInPTags && rumor.pubkey !== myPubkey) {
+        console.warn('Deletion rumor does not include my public key in p-tags, ignoring');
+        return;
+      }
+
+      // Extract e-tags (rumorIds to delete)
+      const eTags = rumor.tags.filter(t => Array.isArray(t) && t.length >= 2 && t[0] === 'e');
+      if (eTags.length === 0) {
+        console.warn('Deletion rumor has no e-tags, ignoring');
+        return;
+      }
+
+      for (const eTag of eTags) {
+        const targetRumorId = eTag[1];
+
+        // Look up message by rumorId (stable ID across all recipients)
+        const message = await messageRepo.getMessageByRumorId(targetRumorId);
+        
+        if (!message) {
+          console.warn('Deletion for unknown rumor:', targetRumorId.substring(0, 16));
+          continue;
+        }
+
+        // CRITICAL: Validate deletion comes from the original message sender
+        const senderPubkey = this.getMessageSenderPubkey(message, myPubkey);
+        if (rumor.pubkey !== senderPubkey) {
+          console.warn('Deletion from non-author, ignoring:', {
+            deletionFrom: rumor.pubkey.substring(0, 8),
+            messageSender: senderPubkey.substring(0, 8),
+            rumorId: targetRumorId.substring(0, 16)
+          });
+          continue;
+        }
+
+        // Mark as deleted
+        if (!message.id) {
+          console.warn('Message has no database ID, cannot mark as deleted');
+          continue;
+        }
+
+        await messageRepo.markMessageDeleted(
+          message.id,
+          rumor.created_at * 1000
+        );
+
+        // Emit UI update event
+        if (typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('nospeak:message-deleted', {
+            detail: { 
+              messageId: message.id,
+              conversationId: message.conversationId,
+              rumorId: targetRumorId
+            }
+          }));
+        }
+
+        if (this.debug) {
+          console.log('Message deleted successfully:', {
+            messageId: message.id,
+            rumorId: targetRumorId,
+            deletedBy: rumor.pubkey.substring(0, 8),
+            reason: rumor.content || '(no reason)'
+          });
+        }
+      }
+    } catch (e) {
+      console.error('Failed to process deletion rumor:', e);
+    }
+  }
+
+  /**
+   * Get the sender pubkey for a message (used for deletion validation).
+   * For sent messages, returns the current user's pubkey.
+   * For received messages, extracts from senderNpub or recipientNpub.
+   */
+  private getMessageSenderPubkey(message: Message, myPubkey: string): string {
+    if (message.direction === 'sent') {
+      return myPubkey;
+    } else if (message.senderNpub) {
+      // Group message: extract from senderNpub
+      return nip19.decode(message.senderNpub).data as string;
+    } else {
+      // 1-on-1 received message: sender is the conversation partner
+      return nip19.decode(message.recipientNpub).data as string;
+    }
+  }
+
+  /**
+   * Check if a message can be deleted by the current user.
+   * Only sent messages can be deleted (you can't delete messages you received).
+   */
+  public canDeleteMessage(message: Message): boolean {
+    return message.direction === 'sent' && !message.deletedAt;
+  }
+
+  /**
+   * Send a deletion request for a message.
+   * Creates a kind 5 rumor and sends it gift-wrapped to all participants.
+   * 
+   * @param message - The message to delete
+   */
+  public async sendDeletionRequest(message: Message): Promise<void> {
+    const s = get(signer);
+    if (!s) throw new Error('Not authenticated');
+
+    // Validate: only sent messages can be deleted
+    if (!this.canDeleteMessage(message)) {
+      throw new Error('Cannot delete this message (only sent messages can be deleted)');
+    }
+
+    if (!message.rumorId) {
+      throw new Error('Message has no rumorId, cannot delete');
+    }
+
+    const myPubkey = await s.getPublicKey();
+    const myNpub = nip19.npubEncode(myPubkey);
+
+    // Determine recipients
+    let recipientNpubs: string[];
+    if (message.participants && message.participants.length > 1) {
+      // Group message: send to all participants except self
+      recipientNpubs = message.participants.filter(npub => npub !== myNpub);
+    } else {
+      // 1-on-1 message: send to the recipient
+      recipientNpubs = [message.recipientNpub];
+    }
+
+    // Include self for cross-device sync
+    const allRecipients = [...recipientNpubs, myNpub];
+
+    // Build deletion rumor
+    const deletionRumor: Partial<NostrEvent> = {
+      kind: 5,
+      pubkey: myPubkey,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [
+        ['e', message.rumorId], // Reference the rumor ID (stable across recipients)
+        ['k', String(message.rumorKind || 14)] // Kind being deleted
+      ],
+      content: ''
+    };
+
+    // Add p-tags for all recipients (NIP-17 compliance)
+    for (const npub of allRecipients) {
+      const pubkey = nip19.decode(npub).data as string;
+      deletionRumor.tags!.push(['p', pubkey]);
+    }
+
+    if (this.debug) {
+      console.log('Sending deletion request:', {
+        rumorId: message.rumorId.substring(0, 16),
+        recipients: allRecipients.length
+      });
+    }
+
+    // Send gift-wrapped deletion to all recipients (including self)
+    try {
+      await this.sendEnvelope({
+        recipients: allRecipients,
+        rumor: deletionRumor,
+        conversationId: message.conversationId,
+        skipDbSave: true // Don't save deletion as a message
+      });
+
+      // Mark deleted locally immediately
+      if (message.id) {
+        await messageRepo.markMessageDeleted(message.id, Date.now());
+        
+        // Emit UI update event
+        if (typeof window !== 'undefined') {
+          // Use setTimeout to ensure event fires after current call stack
+          setTimeout(() => {
+            // For 1-on-1 chats, conversationId should be recipientNpub
+            // For group chats, conversationId is the group hash
+            const conversationId = message.conversationId || message.recipientNpub;
+            
+            window.dispatchEvent(new CustomEvent('nospeak:message-deleted', {
+              detail: { 
+                messageId: message.id,
+                conversationId: conversationId,
+                rumorId: message.rumorId
+              }
+            }));
+          }, 0);
+        }
+      }
+
+      console.log('Deletion request sent successfully');
+    } catch (e) {
+      console.error('Failed to send deletion request:', e);
+      throw new Error('Failed to send deletion request to relays');
+    }
+  }
 
   // Check if this is a first-time sync (empty message cache)
   private async isFirstTimeSync(): Promise<boolean> {

--- a/src/lib/db/MessageRepository.ts
+++ b/src/lib/db/MessageRepository.ts
@@ -221,6 +221,67 @@ export class MessageRepository {
 
         return items[0];
     }
+
+    /**
+     * Mark a message as deleted (NIP-09).
+     * Updates the message with deletion metadata.
+     * 
+     * @param messageId - The database ID of the message to delete
+     * @param deletedAt - Timestamp when the message was deleted
+     */
+    public async markMessageDeleted(messageId: number, deletedAt: number): Promise<void> {
+        const message = await db.messages.get(messageId);
+        if (!message) {
+            console.warn('Cannot mark message as deleted: message not found', messageId);
+            return;
+        }
+
+        // Check if already deleted (idempotent operation)
+        if (message.deletedAt) {
+            console.log('Message already deleted, skipping', messageId);
+            return;
+        }
+
+        await db.messages.update(messageId, {
+            deletedAt
+        });
+
+        console.log('Message marked as deleted:', {
+            messageId,
+            eventId: message.eventId,
+            rumorId: message.rumorId,
+            deletedAt: new Date(deletedAt).toISOString()
+        });
+    }
+
+    /**
+     * Unmark a message as deleted (rollback deletion).
+     * Removes the deletedAt timestamp.
+     * 
+     * @param messageId - The database ID of the message to restore
+     */
+    public async unmarkMessageDeleted(messageId: number): Promise<void> {
+        const message = await db.messages.get(messageId);
+        if (!message) {
+            console.warn('Cannot unmark message as deleted: message not found', messageId);
+            return;
+        }
+
+        if (!message.deletedAt) {
+            console.log('Message is not marked as deleted, skipping', messageId);
+            return;
+        }
+
+        await db.messages.update(messageId, {
+            deletedAt: undefined
+        });
+
+        console.log('Message unmarked as deleted:', {
+            messageId,
+            eventId: message.eventId,
+            rumorId: message.rumorId
+        });
+    }
 }
 
 export const messageRepo = new MessageRepository();

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -31,6 +31,8 @@ export interface Message {
     conversationId?: string; // npub for 1-on-1, hash for groups
     participants?: string[]; // null/undefined for 1-on-1, array of npubs for groups
     senderNpub?: string; // sender's npub for group messages (to show attribution)
+    // Message deletion (NIP-09)
+    deletedAt?: number; // timestamp when message was deleted
 }
 
 export interface Conversation {
@@ -203,6 +205,13 @@ export class NospeakDB extends Dexie {
         // Version 12: Add archives table for chat archiving
         this.version(12).stores({
             archives: 'conversationId, archivedAt'
+        });
+
+        // Version 13: Add deletion support (NIP-09)
+        // No schema changes needed - deletedAt is an optional field
+        // that can be added to existing records without migration
+        this.version(13).stores({
+            messages: '++id, [recipientNpub+sentAt], &eventId, sentAt, rumorId, [conversationId+sentAt]'
         });
     }
 

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -305,8 +305,18 @@ const en = {
             copy: 'Copy',
             sentAt: 'Sent',
             favorite: 'Favorite',
-            unfavorite: 'Remove favorite'
+            unfavorite: 'Remove favorite',
+            delete: 'Delete'
         },
+        delete: {
+            confirmTitle: 'Delete Message?',
+            privacyNotice: 'This will request that all participants in this conversation hide your message, but copies may remain on relays and in apps.',
+            cancel: 'Cancel',
+            confirm: 'Delete',
+            failedTitle: 'Delete Failed',
+            failedMessagePrefix: 'Failed to delete message: '
+        },
+        messageDeleted: 'This message was deleted',
         reactions: {
             cannotReactTitle: 'Cannot React',
             cannotReactMessage: 'This message is too old to support reactions.',

--- a/src/routes/chat/[npub]/+page.svelte
+++ b/src/routes/chat/[npub]/+page.svelte
@@ -408,15 +408,62 @@
             }
         };
 
+        // Listen for message deletion events
+        const handleMessageDeleted = async (event: Event) => {
+            const custom = event as CustomEvent<{ messageId?: number; conversationId?: string; rumorId?: string }>;
+            const convId = conversationId;
+            if (!convId) return;
+
+            const { messageId, conversationId: msgConvId } = custom.detail || {};
+
+            // For ALL view, do full refresh
+            if (convId === 'ALL') {
+                refreshMessagesForCurrentConversation();
+                return;
+            }
+
+            // Check if deletion is for current conversation
+            const matchesConversation = msgConvId === convId;
+            if (!matchesConversation) {
+                return;
+            }
+
+            // Find and update the message in the local array
+            if (messageId) {
+                const messageIndex = messages.findIndex(m => m.id === messageId);
+                if (messageIndex !== -1) {
+                    // Fetch the updated message from DB with a small delay to ensure write is complete
+                    await new Promise(resolve => setTimeout(resolve, 50));
+                    const updatedMessage = await messageRepo.getMessageByEventId(messages[messageIndex].eventId);
+                    if (updatedMessage) {
+                        // Update the message in place to trigger reactivity
+                        messages = [
+                            ...messages.slice(0, messageIndex),
+                            updatedMessage,
+                            ...messages.slice(messageIndex + 1)
+                        ];
+                    }
+                } else {
+                    // Message not in current view, might need refresh
+                    refreshMessagesForCurrentConversation();
+                }
+            } else {
+                // Fallback to full refresh
+                refreshMessagesForCurrentConversation();
+            }
+        };
+
         if (typeof window !== 'undefined') {
             window.addEventListener('nospeak:new-message', handleNewMessage);
             window.addEventListener('nospeak:conversation-updated', handleConversationUpdated);
+            window.addEventListener('nospeak:message-deleted', handleMessageDeleted);
         }
 
         return () => {
             if (typeof window !== 'undefined') {
                 window.removeEventListener('nospeak:new-message', handleNewMessage);
                 window.removeEventListener('nospeak:conversation-updated', handleConversationUpdated);
+                window.removeEventListener('nospeak:message-deleted', handleMessageDeleted);
             }
         };
     });


### PR DESCRIPTION
Add support for deleting sent messages in both 1-on-1 and group chats
following NIP-09 specification with enhanced privacy guarantees.

Features:
- Gift-wrapped deletion requests (kind 5 rumors) to prevent metadata leaks
- Real-time UI updates across all browsers (Firefox, Chrome)
- Cross-device sync via self-addressed deletion events
- Optimistic UI with automatic rollback on relay failures
- Context menu integration with confirmation dialog
- Group chat support with per-participant validation
- Sender-only deletion (users cannot delete received messages)

Implementation details:
- Database schema: Added deletedAt field to Message interface (v13 migration)
- Messaging service: processDeletionRumor() validates sender, sendDeletionRequest() 
  creates gift-wrapped kind 5 events
- Repository: markMessageDeleted() and unmarkMessageDeleted() for rollback
- UI: Deleted message placeholder with trash icon, simplified confirmation dialog
- Event system: nospeak:message-deleted for reactive updates
- Tested against Amethyst 1.05.1-PLAY: Delete requests initiated in nospeak are honored in Amethyst; requests initiated in Amethyst are not honored in nospeak since nospeak does not fetch (or publish) public kind 5. This design choice is meant to mitigate metadata leakage.

Privacy guarantees:
- Zero metadata leak: All deletions sent as encrypted gift wraps (kind 1059)
- No public kind 5 events: Maintains NIP-17 privacy model throughout
- Relay-agnostic: Client-side validation, no dependency on relay cooperation
- Social graph protection: Cannot link participants via deletion events